### PR TITLE
Use `mdbook::utils::new_cmark_parser` to preserve tables

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,14 +22,17 @@ fn main() -> Result {
 	let opts = cli::init()?;
 
 	// handle supports or processing:
+	let bob = preprocessor::Bob::new();
 	if let Some(cli::Commands::Supports { renderer }) = opts.command {
-		let bob = preprocessor::Bob::new();
 		// Signal whether the renderer is supported by exiting with 1 or 0.
 		if bob.supports_renderer(&renderer) {
 			process::exit(0);
 		} else {
 			process::exit(1);
 		}
+	} else if let Err(e) = bob.handle_preprocessing() {
+		error!("{}", e);
+		process::exit(1);
 	}
 
 	Ok(())

--- a/src/preprocessor.rs
+++ b/src/preprocessor.rs
@@ -73,10 +73,9 @@ impl Preprocessor for Bob {
 	}
 }
 
-
 /// Find code-blocks \`\`\`bob, produce svg and place it instead code.
 fn process_code_blocks(chapter: &mut Chapter, cfg: &Cfg) -> Result<String, std::fmt::Error> {
-	use pulldown_cmark::{Parser, CodeBlockKind, Event, CowStr, Tag};
+	use pulldown_cmark::{CodeBlockKind, Event, CowStr, Tag};
 	use pulldown_cmark_to_cmark::cmark;
 
 	enum State {
@@ -87,36 +86,40 @@ fn process_code_blocks(chapter: &mut Chapter, cfg: &Cfg) -> Result<String, std::
 
 	let mut state = State::None;
 	let mut buf = String::with_capacity(chapter.content.len());
-	let events =
-		Parser::new(&chapter.content).map(|e| {
-			                             use State::*;
-			                             use Event::*;
-			                             use CowStr::*;
-			                             use CodeBlockKind::*;
-			                             use Tag::{CodeBlock, Paragraph};
+	// The curly_quotes setting is left at false so that people can
+	// set it in book.toml (mdBook will apply the setting when it
+	// parses our output). It is important to use new_cmark_parser so
+	// that we parse things like tables consistently with mdBook.
+	let parser = mdbook::utils::new_cmark_parser(&chapter.content, false);
+	let events = parser
+		.map(|e| {
+			use State::*;
+			use Event::*;
+			use CowStr::*;
+			use CodeBlockKind::*;
+			use Tag::{CodeBlock, Paragraph};
 
-			                             match (&e, &mut state) {
-				                             (Start(CodeBlock(Fenced(Borrowed(mark)))), None) if mark == &cfg.code_block => {
-				                                state = Open;
-				                                Some(Start(Paragraph))
-			                                },
+			match (&e, &mut state) {
+				(Start(CodeBlock(Fenced(Borrowed(mark)))), None) if mark == &cfg.code_block => {
+					state = Open;
+					Some(Start(Paragraph))
+				},
 
-			                                (Text(Borrowed(text)), Open) => {
-				                                state = Closing;
-				                                Some(Html(bob_handler(text, &cfg.settings).into()))
-			                                },
+				(Text(Borrowed(text)), Open) => {
+					state = Closing;
+					Some(Html(bob_handler(text, &cfg.settings).into()))
+				},
 
-			                                (End(CodeBlock(Fenced(Borrowed(mark)))), Closing) if mark == &cfg.code_block => {
-				                                state = None;
-				                                Some(End(Paragraph))
-			                                },
-			                                _ => Some(e),
-			                             }
-		                             })
-		                             .flatten();
+				(End(CodeBlock(Fenced(Borrowed(mark)))), Closing) if mark == &cfg.code_block => {
+					state = None;
+					Some(End(Paragraph))
+				},
+				_ => Some(e),
+			}
+		})
+		.flatten();
 	cmark(events, &mut buf).map(|_| buf)
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Before, we would ignore the Markdown settings from mdBook and parse the content with default settings. This meant that we did not support Markdown tables, which are an extension to regular Markdown. The result was that tables were mangled after the preprocessor had run. They looked like this:

![image](https://user-images.githubusercontent.com/89623/205037260-3ec4bbb3-2db9-4d06-86cd-14bbcb7d5f73.png)

We now use the mdBook utility function to construct the Markdown parser, thus getting consistent results. This makes tables survive the parsing.

The PR also has a commit which restores the preprocessing functionality, it was accidentally lost in the refactor in https://github.com/boozook/mdbook-svgbob/commit/900cd776bc0bc2dd52587720e29f6acec61d4e66.