### PR TITLE
Fix svgbob diagrams in dark mode

### DIFF
--- a/src/svgbob.rs
+++ b/src/svgbob.rs
@@ -16,5 +16,5 @@ pub fn bob_handler(s: &str, settings: &Settings) -> String {
 	svg.render_with_indent(&mut source, 0, true).expect("html render");
 
 	let style = Style::new("svg { width: 100% !important; }").set("type", "text/css");
-	format!("<div style='width:100%; height:{}px;'>{}{}</div>", height, style, source).replace('\n', "")
+	format!("<div style='width:100%; height:{}px; fill:var(--fg);'>{}{}</div>", height, style, source).replace('\n', "")
 }


### PR DESCRIPTION
Closes https://github.com/boozook/mdbook-svgbob/issues/22

Currently, the SVG text elements receive the default color, black, which is not readable on dark mode. 

This PR adds a one-liner CSS fix to apply the foreground css variable (var(--fg)) to the svg text element to make svg text legible and visible.